### PR TITLE
temporary adc.c fix

### DIFF
--- a/MMM.c
+++ b/MMM.c
@@ -181,7 +181,7 @@ void MMMSiliconSort(float *ADC_import, int ntdc, int *TDC_channel_import, float 
   //printf("SiliconData PrintEvent routine: Silicon hits: %d\n",si->SizeOfEvent());
   //si->PrintEvent();
   //printf("MMM.c L180\n");
-  if(!si->TestEvent()); si->ClearEvent(); //If the event fails for some reason, we void it and clear it here. The number of these should be logged and, ideally, should be zero. A VOIDED EVENT IS ONE IN WHICH ALL SILICON DATA ARE THROWN AWAY BECAUSE THE RESULT IS **WRONG**. There are more energy hits than theta hits, for example. IT THEY ARE HAPPENING, THEN YOU'VE DONE IT WRONG.
+  if(!si->TestEvent()) si->ClearEvent(); //If the event fails for some reason, we void it and clear it here. The number of these should be logged and, ideally, should be zero. A VOIDED EVENT IS ONE IN WHICH ALL SILICON DATA ARE THROWN AWAY BECAUSE THE RESULT IS **WRONG**. There are more energy hits than theta hits, for example. IT THEY ARE HAPPENING, THEN YOU'VE DONE IT WRONG.
   //printf("MMM.c L182\n");
   //MMMGhostBuster(SiliconData *si);
 

--- a/Parameters.c
+++ b/Parameters.c
@@ -85,7 +85,7 @@ void ParameterInit()
   QDCInit();
   TDCInit();
   PrintParameters();
-  printf("Finished initialising parameters - to the sorting!\n");
+  printf("\nFinished initialising parameters - to the sorting!\n");
 }
 
 /*-------------------------------------------------*/

--- a/Parameters.h
+++ b/Parameters.h
@@ -7,8 +7,9 @@
 #include <cstdlib>
 #include <limits>
 
-// Originally declared as constants; some are needed in array definitions, and some I
-// just tried to make a distinction between things one can change and things one should not change at all
+// Originally declared as constants, sinc I tried to make a distinction
+// between things one can change and things one should not change at all ... RN
+
 const double X_WIRESPACE = 4.0;     // distance (mm) between signal wires
 const double DRIFTLENGTH = 8.0;     // max distance (mm) the electrons can drift
 const double U_WIRE_ANGLE=50.0;     // angle of wires in U-plane wrt to horizontal
@@ -23,9 +24,8 @@ const int MAX_WIRES_PER_EVENT = 400;  // If more wires than this fire, the event
 				      // MUST FIND A BETTER WAY ... THIS VARIABLE NOT GOOD?
 const int LUT_CHANNELS=9000;
 const int TDC_CHAN_PULSER=2;      // A pulser PR, in absence of pattern register unit
-
-const int TDC_CHAN_POLU=4;        // May 2016: this was last used in PR153 Oct 2011
-const int TDC_CHAN_POLD=5;
+const int TDC_CHAN_POLU=4;        // May 2016: this was last used in PR153 Oct 2010
+const int TDC_CHAN_POLD=5;        // May 2016: this was last used in PR153 Oct 2010
 
 
 

--- a/Parameters.h
+++ b/Parameters.h
@@ -9,22 +9,24 @@
 
 // Originally declared as constants; some are needed in array definitions, and some I
 // just tried to make a distinction between things one can change and things one should not change at all
-const double X_WIRESPACE = 4.0;  // distance (mm) between signal wires
-const double DRIFTLENGTH = 8.0;  // max distance (mm) the electrons can drift
-const double U_WIRE_ANGLE=50.0;    // angle of wires in U-plane wrt to horizontal
+const double X_WIRESPACE = 4.0;     // distance (mm) between signal wires
+const double DRIFTLENGTH = 8.0;     // max distance (mm) the electrons can drift
+const double U_WIRE_ANGLE=50.0;     // angle of wires in U-plane wrt to horizontal
 const int X_WIRES=208;
 const int U_WIRES=145;
 const int TDC_MAX_TIME=14999;
 const int TDC_MIN_TIME=0;
 const int TDC_N_BINS=14999;
-const int TOF_TDC_CHAN=1;     // ch1 in 1st TDC; i.e. the 2nd channel     
+const int TOF_TDC_CHAN=1;             // ch1 in 1st TDC; i.e. the 2nd channel     
 const int MAX_WIRES_PER_EVENT = 400;  // If more wires than this fire, the event data was bad  -- RN random choice  -- 
 				      // to be replaced by something else?!?! really only used for array definition
 				      // MUST FIND A BETTER WAY ... THIS VARIABLE NOT GOOD?
 const int LUT_CHANNELS=9000;
-const int TDC_CHAN_PULSER=2;
+const int TDC_CHAN_PULSER=2;      // A pulser PR, in absence of pattern register unit
 
-//const int NR_OF_TDCS=7;     // this value is now declared in the config file config.cfg, as it can change from exp to exp
+const int TDC_CHAN_POLU=4;        // May 2016: this was last used in PR153 Oct 2011
+const int TDC_CHAN_POLD=5;
+
 
 
 

--- a/adc.c
+++ b/adc.c
@@ -25,15 +25,8 @@
 //#include <TMath.h>
 
 
-// defined in Parameters.c
-extern float *ADC;
-extern int ADCModules;
-extern int ADCsize;
-extern double *ADCOffsets, *ADCGains;
 
-/*-- variables to be used in f-plane.c as extern variables----------*/
-//float ADC[128];
-
+/*-- variables to be used in main.c as extern variables----------*/
 int adcevtcount;
 
 
@@ -64,18 +57,26 @@ ANA_MODULE adc_module = {
 
 
 /*--------------------------------------------------------------------------*/
-#define H1I_BOOK(n,t,b,min,max) (h1_book<TH1I>(n,t,b,min,max))
-#define H2I_BOOK(n,t,xb,xmin,xmax,yb,ymin,ymax) (h2_book<TH2I>(n,t,xb,xmin,xmax,yb,ymin,ymax))
+//#define H1I_BOOK(n,t,b,min,max) (h1_book<TH1I>(n,t,b,min,max))
+//#define H2I_BOOK(n,t,xb,xmin,xmax,yb,ymin,ymax) (h2_book<TH2I>(n,t,xb,xmin,xmax,yb,ymin,ymax))
+
+// defined in Parameters.c
+extern float *ADC;
+extern int ADCModules;
+extern int ADCsize;
+extern double *ADCOffsets, *ADCGains;
 
 /*------------Declarations of predefined Constants ----------------*/
-const int ADC_N_BINS = 4096;
-const int ADC_X_LOW  = 0;
-const int ADC_X_HIGH = 4095;
+//const int ADC_N_BINS = 4096;
+//const int ADC_X_LOW  = 0;
+//const int ADC_X_HIGH = 4095;
 extern EXP_PARAM exp_param;
 extern RUNINFO runinfo;
 
 /*-- Histogramming Data Structures ----------------------------------------*/
 TH2F **hADC2DModule;
+//static TH2F *hADC2DModule[5];
+
 
 /*-- init routine --------------------------------------------------*/
 INT adc_init(void)
@@ -83,14 +84,21 @@ INT adc_init(void)
    char name[256];
    char title[256];
    int i;
-
+  
    hADC2DModule = new TH2F*[ADCModules];   
    for(int counter=0;counter<ADCModules;counter++){
 	  sprintf(name,"hADC2DModule%d",counter);
 	  sprintf(title,"hADC2DModule %d ",counter);
           hADC2DModule[counter]=new TH2F(name,title,4096,0,4096,32,0,32);
-   }
+  }
 
+/*
+   for(int counter=0;counter<5;counter++){
+	  sprintf(name,"hADC2DModule%d",counter);
+	  sprintf(title,"hADC2DModule %d ",counter);
+          hADC2DModule[counter]=H2_BOOK(name,title,4096,0,4096,32,0,32);
+   }
+*/
    return SUCCESS;
 }
 
@@ -150,8 +158,9 @@ INT adc_event(EVENT_HEADER * pheader, void *pevent)
 {
    INT i, nwords;
    DWORD *padc;
-   float *adc = new float[32*ADCModules];  
-//    printf("adc initialisation: %d\n",32*ADCModules);
+   //float *adc = new float[32*ADCModules];  
+   float *adc = new float[32];  
+   //printf("adc initialisation: %d\n",32*ADCModules);
    int adcchan,adcnr;
    extern int adc_counter1, adc_counter2;   // defined; declared in analyzer.c
 
@@ -162,7 +171,8 @@ INT adc_event(EVENT_HEADER * pheader, void *pevent)
       adc_counter2++;
       return 1;
    }
-//     printf("adc.c: L185\n");     
+
+   //printf("adc.c: L176\n");     
    for (i = 0; i < nwords; i++){
         //printf("-------raw data 0x%08x  Nr of words %d \n",padc[i],nwords); 
         if(((padc[i]>>24)&0xff) ==0xfd) {
@@ -179,8 +189,10 @@ INT adc_event(EVENT_HEADER * pheader, void *pevent)
             adcchan=adcchan + adcnr*32;
       	    adc[adcchan] =(float)(padc[i]&0x0fff);
             //printf("raw data 0x%08x -> chan %d data %d adcnr %i words %d \n",padc[i],adcchan,(padc[i]&0x0fff),adcnr,nwords);
-
+          
             /* fill basic ADC histos */
+	    //hADC2DModule[adcnr]->Fill(adc[adcchan],adcchan);
+/*
             if(adcchan<32) {
 		hADC2DModule[0]->Fill(adc[adcchan],adcchan);
 	    }  
@@ -194,6 +206,7 @@ INT adc_event(EVENT_HEADER * pheader, void *pevent)
 		hADC2DModule[3]->Fill(adc[adcchan],adcchan-96);
 	    }
             else if(adcchan<160) hADC2DModule[4]->Fill(adc[adcchan],adcchan-128);  
+*/
 	}
 
    }

--- a/basic.odb
+++ b/basic.odb
@@ -1,29 +1,12 @@
-[/System/Clients/23999]
+[/System/Clients/17517]
 Name = STRING : [32] ODBEdit
 Host = STRING : [256] rnlap.tlabs.ac.za
 Hardware type = INT : 44
-Server Port = INT : 59240
-
-[/System/Clients/24857]
-Name = STRING : [32] ODBEdit1
-Host = STRING : [256] rnlap.tlabs.ac.za
-Hardware type = INT : 44
-Server Port = INT : 47116
+Server Port = INT : 46705
 
 [/System]
 Client Notify = INT : 0
 Prompt = STRING : [256] [%h:%e:%s]%p>
-
-[/Programs/ODBEdit]
-Required = BOOL : n
-Watchdog timeout = INT : 10000
-Check interval = DWORD : 180000
-Start command = STRING : [256] 
-Auto start = BOOL : n
-Auto stop = BOOL : n
-Auto restart = BOOL : n
-Alarm class = STRING : [32] 
-First failed = DWORD : 1281101553
 
 [/Programs/Analyzer]
 Required = BOOL : n
@@ -35,6 +18,17 @@ Auto stop = BOOL : n
 Auto restart = BOOL : n
 Alarm class = STRING : [32] 
 First failed = DWORD : 0
+
+[/Programs/ODBEdit]
+Required = BOOL : n
+Watchdog timeout = INT : 10000
+Check interval = DWORD : 180000
+Start command = STRING : [256] 
+Auto start = BOOL : n
+Auto stop = BOOL : n
+Auto restart = BOOL : n
+Alarm class = STRING : [32] 
+First failed = DWORD : 1281101553
 
 [/Programs/mhttpd]
 Required = BOOL : y
@@ -164,14 +158,14 @@ First failed = DWORD : 1262694156
 [/Experiment]
 Name = STRING : [32] Default
 
+[/Experiment/Run Parameters]
+Comment = STRING : [80] Analysis
+
 [/Experiment/Buffer sizes]
 SYSMSG = DWORD : 100000
 SYSTEM = DWORD : 4194304
 k600SYSTEMSCALER = DWORD : 8388608
 SYSTEMSCALER = DWORD : 8388608
-
-[/Experiment/Run Parameters]
-Comment = STRING : [80] Analysis
 
 [/Experiment/Lock when running]
 Run parameter = LINK : [27] /Experiment/Run parameters
@@ -243,253 +237,6 @@ Start time = STRING : [32] Thu Oct 16 14:26:35 2008
 Start time binary = DWORD : 1224159995
 Stop time = STRING : [32] Thu Oct 16 14:26:44 2008
 Stop time binary = DWORD : 1224160004
-
-[/Alarms]
-Alarm system active = BOOL : y
-
-[/Alarms/Alarms/Demo ODB]
-Active = BOOL : n
-Triggered = INT : 0
-Type = INT : 3
-Check interval = INT : 60
-Checked last = DWORD : 0
-Time triggered first = STRING : [32] 
-Time triggered last = STRING : [32] 
-Condition = STRING : [256] /Runinfo/Run number > 100
-Alarm Class = STRING : [32] Alarm
-Alarm Message = STRING : [80] Run number became too large
-
-[/Alarms/Alarms/Demo periodic]
-Active = BOOL : n
-Triggered = INT : 0
-Type = INT : 4
-Check interval = INT : 28800
-Checked last = DWORD : 1176474143
-Time triggered first = STRING : [32] 
-Time triggered last = STRING : [32] 
-Condition = STRING : [256] 
-Alarm Class = STRING : [32] Warning
-Alarm Message = STRING : [80] Please do your shift checks
-
-[/Alarms/Alarms/EventRate]
-Active = BOOL : y
-Triggered = INT : 12
-Type = INT : 3
-Check interval = INT : 5
-Checked last = DWORD : 1418898692
-Time triggered first = STRING : [32] Tue Jan  5 14:22:36 2010
-Time triggered last = STRING : [32] Thu Dec 18 12:31:32 2014
-Condition = STRING : [256] /Equipment/WireChamber/Statistics/Events per sec. <  120
-Alarm Class = STRING : [32] Alarm
-Alarm Message = STRING : [80] Event Rate has dropped too low
-
-[/Alarms/Alarms/Speaker]
-Active = BOOL : y
-Triggered = INT : 0
-Type = INT : 2
-Check interval = INT : 60
-Checked last = DWORD : 0
-Time triggered first = STRING : [32] 
-Time triggered last = STRING : [32] 
-Condition = STRING : [256] on
-Alarm Class = STRING : [32] Alarm
-Alarm Message = STRING : [80] Program Speaker is not running
-
-[/Alarms/Classes/Alarm]
-Write system message = BOOL : y
-Write Elog message = BOOL : n
-System message interval = INT : 60
-System message last = DWORD : 1418898692
-Execute command = STRING : [256] 
-Execute interval = INT : 0
-Execute last = DWORD : 0
-Stop run = BOOL : n
-Display BGColor = STRING : [32] red
-Display FGColor = STRING : [32] black
-
-[/Alarms/Classes/Warning]
-Write system message = BOOL : y
-Write Elog message = BOOL : n
-System message interval = INT : 60
-System message last = DWORD : 0
-Execute command = STRING : [256] 
-Execute interval = INT : 0
-Execute last = DWORD : 0
-Stop run = BOOL : n
-Display BGColor = STRING : [32] red
-Display FGColor = STRING : [32] black
-
-[/Analyzer/Parameters/focalplane]
-x1_driftt_low = INT : 6100
-x1_driftt_hi = INT : 8050
-x2_driftt_low = INT : 6100
-u1_driftt_low = INT : 6100
-u2_driftt_low = INT : 6100
-x2_driftt_hi = INT : 8050
-u2_driftt_hi = INT : 8050
-u1_driftt_hi = INT : 8050
-lowtof = INT : 2000
-hitof = INT : 7000
-lowpad1 = INT : 0
-lowpad2 = INT : 0
-hipad1 = INT : 4096
-hipad2 = INT : 4096
-
-[/Analyzer/Parameters/GLOBAL]
-misswires = INT : 2
-max_tdc_channels = INT : 1000
-min_x_wires = INT : 3
-min_u_wires = INT : 3
-max_x_wires = INT : 9
-max_u_wires = INT : 8
-lut_x1_offset = INT : 0
-lut_u1_offset = INT : 0
-lut_x2_offset = INT : 0
-lut_u2_offset = INT : 0
-x1_1st_wire_chan = INT : 0
-x1_last_wire_chan = INT : 200
-x2_1st_wire_chan = INT : 500
-x2_last_wire_chan = INT : 700
-u1_1st_wire_chan = INT : 300
-u1_last_wire_chan = INT : 443
-u2_1st_wire_chan = INT : 800
-u2_last_wire_chan = INT : 943
-
-[/Analyzer/Parameters/main]
-x1_driftt_low = INT : 6100
-x1_driftt_hi = INT : 8050
-x2_driftt_low = INT : 6100
-u1_driftt_low = INT : 6100
-u2_driftt_low = INT : 6100
-x2_driftt_hi = INT : 8050
-u2_driftt_hi = INT : 8050
-u1_driftt_hi = INT : 8050
-lowtof = INT : 2000
-hitof = INT : 6000
-lowpad1 = INT : 1
-lowpad2 = INT : 0
-hipad1 = INT : 4096
-hipad2 = INT : 4096
-
-[/Analyzer/Output]
-Filename = STRING : [256] 
-RWNT = BOOL : n
-Histo Dump = BOOL : y
-Histo Dump Filename = STRING : [256] his%05d.root
-Clear histos = BOOL : y
-Last Histo Filename = STRING : [256] last.root
-Events to ODB = BOOL : y
-Global Memory Name = STRING : [8] ONLN
-
-[/Analyzer/Module switches]
-ADC = BOOL : y
-QDC = BOOL : y
-main = BOOL : y
-Scalers = BOOL : y
-focalplane = BOOL : y
-ADC calibration = BOOL : y
-Scaler accumulation = BOOL : y
-ADC summing = BOOL : y
-test space = BOOL : y
-Focal Plane = BOOL : y
-WireChamber = BOOL : y
-ADCcalibration = BOOL : y
-ADCsumming = BOOL : y
-Drift Chambers = BOOL : y
-SIMSORT = BOOL : y
-
-[/Analyzer/Trigger/Common]
-Event ID = INT : 1
-Trigger mask = INT : -1
-Sampling type = INT : 2
-Buffer = STRING : [32] SYSTEM
-Enabled = BOOL : y
-Client name = STRING : [32] Analyzer
-Host = STRING : [32] rnlap.tlabs.ac.za
-
-[/Analyzer/Trigger/Statistics]
-Events received = DOUBLE : 0
-Events per sec. = DOUBLE : 0
-Events written = DOUBLE : 0
-
-[/Analyzer/Scaler/Common]
-Event ID = INT : 2
-Trigger mask = INT : -1
-Sampling type = INT : 1
-Buffer = STRING : [32] SYSTEM
-Enabled = BOOL : y
-Client name = STRING : [32] Analyzer
-Host = STRING : [32] rnlap.tlabs.ac.za
-
-[/Analyzer/Scaler/Statistics]
-Events received = DOUBLE : 0
-Events per sec. = DOUBLE : 0
-Events written = DOUBLE : 0
-
-[/Analyzer/Bank switches]
-ADC0 = DWORD : 1
-QDC0 = DWORD : 1
-TDC0 = DWORD : 1
-SCLR = DWORD : 1
-PAT0 = DWORD : 1
-ACUM = DWORD : 1
-CADC = DWORD : 1
-ASUM = DWORD : 1
-ETCR = DWORD : 0
-PADD = DWORD : 1
-TDC1 = DWORD : 1
-SCLD = DWORD : 1
-
-[/Analyzer]
-Book TTree = BOOL : n
-ODB Load = BOOL : n
-
-[/Analyzer/WireChamber/Common]
-Event ID = INT : 1
-Trigger mask = INT : -1
-Sampling type = INT : 2
-Buffer = STRING : [32] SYSTEM
-Enabled = BOOL : y
-Client name = STRING : [32] Analyzer
-Host = STRING : [32] k600daq
-
-[/Analyzer/WireChamber/Statistics]
-Events received = DOUBLE : 4366
-Events per sec. = DOUBLE : 49500
-Events written = DOUBLE : 0
-
-[/Analyzer/Tree switches/run]
-Read = BOOL : n
-Write = BOOL : n
-Fill = BOOL : n
-Save Config = BOOL : n
-Compression Level = INT : 0
-Max Entries = INT : 0
-
-[/Analyzer/Tasks/PrintValues]
-Active = BOOL : n
-TaskTestValue = INT : 0
-
-[/Analyzer/Tasks/GenerateRawSpectra]
-Active = BOOL : n
-
-[/Analyzer/Tasks/FillRawSpectra]
-Active = BOOL : n
-
-[/Analyzer/Global Steering Parameters]
-TestValue = INT : 0
-
-[/Analyzer/Tabs/Raw]
-Active = BOOL : n
-
-[/Analyzer/Tabs/Wires]
-Active = BOOL : n
-
-[/Analyzer/Tabs/Mon]
-Active = BOOL : n
-
-[/Analyzer/Tabs/WireHits]
-Active = BOOL : n
 
 [/Equipment/Trigger/Variables]
 ADC0 = DWORD : 0
@@ -2927,6 +2674,81 @@ Events sent = DOUBLE : 0
 Events per sec. = DOUBLE : 0
 kBytes per sec. = DOUBLE : 0
 
+[/Alarms]
+Alarm system active = BOOL : y
+
+[/Alarms/Alarms/Demo ODB]
+Active = BOOL : n
+Triggered = INT : 0
+Type = INT : 3
+Check interval = INT : 60
+Checked last = DWORD : 0
+Time triggered first = STRING : [32] 
+Time triggered last = STRING : [32] 
+Condition = STRING : [256] /Runinfo/Run number > 100
+Alarm Class = STRING : [32] Alarm
+Alarm Message = STRING : [80] Run number became too large
+
+[/Alarms/Alarms/Demo periodic]
+Active = BOOL : n
+Triggered = INT : 0
+Type = INT : 4
+Check interval = INT : 28800
+Checked last = DWORD : 1176474143
+Time triggered first = STRING : [32] 
+Time triggered last = STRING : [32] 
+Condition = STRING : [256] 
+Alarm Class = STRING : [32] Warning
+Alarm Message = STRING : [80] Please do your shift checks
+
+[/Alarms/Alarms/EventRate]
+Active = BOOL : y
+Triggered = INT : 12
+Type = INT : 3
+Check interval = INT : 5
+Checked last = DWORD : 1418898692
+Time triggered first = STRING : [32] Tue Jan  5 14:22:36 2010
+Time triggered last = STRING : [32] Thu Dec 18 12:31:32 2014
+Condition = STRING : [256] /Equipment/WireChamber/Statistics/Events per sec. <  120
+Alarm Class = STRING : [32] Alarm
+Alarm Message = STRING : [80] Event Rate has dropped too low
+
+[/Alarms/Alarms/Speaker]
+Active = BOOL : y
+Triggered = INT : 0
+Type = INT : 2
+Check interval = INT : 60
+Checked last = DWORD : 0
+Time triggered first = STRING : [32] 
+Time triggered last = STRING : [32] 
+Condition = STRING : [256] on
+Alarm Class = STRING : [32] Alarm
+Alarm Message = STRING : [80] Program Speaker is not running
+
+[/Alarms/Classes/Alarm]
+Write system message = BOOL : y
+Write Elog message = BOOL : n
+System message interval = INT : 60
+System message last = DWORD : 1418898692
+Execute command = STRING : [256] 
+Execute interval = INT : 0
+Execute last = DWORD : 0
+Stop run = BOOL : n
+Display BGColor = STRING : [32] red
+Display FGColor = STRING : [32] black
+
+[/Alarms/Classes/Warning]
+Write system message = BOOL : y
+Write Elog message = BOOL : n
+System message interval = INT : 60
+System message last = DWORD : 0
+Execute command = STRING : [256] 
+Execute interval = INT : 0
+Execute last = DWORD : 0
+Stop run = BOOL : n
+Display BGColor = STRING : [32] red
+Display FGColor = STRING : [32] black
+
 [/History/Display/Default/WireChamber rate]
 Time Scale = STRING : [32] 1h
 Factor = FLOAT[2] :
@@ -3067,4 +2889,160 @@ boolvalue = BOOL : n
 fltvalue = DOUBLE : 0
 wordvalue = DWORD : 0
 intarr = INT : 0
+
+[/Analyzer/Parameters/focalplane]
+x1_driftt_low = INT : 6100
+x1_driftt_hi = INT : 8050
+x2_driftt_low = INT : 6100
+u1_driftt_low = INT : 6100
+u2_driftt_low = INT : 6100
+x2_driftt_hi = INT : 8050
+u2_driftt_hi = INT : 8050
+u1_driftt_hi = INT : 8050
+lowtof = INT : 2000
+hitof = INT : 7000
+lowpad1 = INT : 0
+lowpad2 = INT : 0
+hipad1 = INT : 4096
+hipad2 = INT : 4096
+
+[/Analyzer/Parameters/GLOBAL]
+misswires = INT : 2
+max_tdc_channels = INT : 1000
+min_x_wires = INT : 3
+min_u_wires = INT : 3
+max_x_wires = INT : 9
+max_u_wires = INT : 8
+lut_x1_offset = INT : 0
+lut_u1_offset = INT : 0
+lut_x2_offset = INT : 0
+lut_u2_offset = INT : 0
+x1_1st_wire_chan = INT : 0
+x1_last_wire_chan = INT : 200
+x2_1st_wire_chan = INT : 500
+x2_last_wire_chan = INT : 700
+u1_1st_wire_chan = INT : 300
+u1_last_wire_chan = INT : 443
+u2_1st_wire_chan = INT : 800
+u2_last_wire_chan = INT : 943
+
+[/Analyzer/Output]
+Filename = STRING : [256] 
+RWNT = BOOL : n
+Histo Dump = BOOL : y
+Histo Dump Filename = STRING : [256] his%05d.root
+Clear histos = BOOL : y
+Last Histo Filename = STRING : [256] last.root
+Events to ODB = BOOL : y
+Global Memory Name = STRING : [8] ONLN
+
+[/Analyzer/Module switches]
+ADC = BOOL : y
+QDC = BOOL : y
+main = BOOL : y
+Scalers = BOOL : y
+focalplane = BOOL : y
+ADC calibration = BOOL : y
+Scaler accumulation = BOOL : y
+ADC summing = BOOL : y
+test space = BOOL : y
+Focal Plane = BOOL : y
+WireChamber = BOOL : y
+ADCcalibration = BOOL : y
+ADCsumming = BOOL : y
+Drift Chambers = BOOL : y
+SIMSORT = BOOL : y
+
+[/Analyzer/Trigger/Common]
+Event ID = INT : 1
+Trigger mask = INT : -1
+Sampling type = INT : 2
+Buffer = STRING : [32] SYSTEM
+Enabled = BOOL : y
+Client name = STRING : [32] Analyzer
+Host = STRING : [32] rnlap.tlabs.ac.za
+
+[/Analyzer/Trigger/Statistics]
+Events received = DOUBLE : 0
+Events per sec. = DOUBLE : 0
+Events written = DOUBLE : 0
+
+[/Analyzer/Scaler/Common]
+Event ID = INT : 2
+Trigger mask = INT : -1
+Sampling type = INT : 1
+Buffer = STRING : [32] SYSTEM
+Enabled = BOOL : y
+Client name = STRING : [32] Analyzer
+Host = STRING : [32] rnlap.tlabs.ac.za
+
+[/Analyzer/Scaler/Statistics]
+Events received = DOUBLE : 0
+Events per sec. = DOUBLE : 0
+Events written = DOUBLE : 0
+
+[/Analyzer/Bank switches]
+ADC0 = DWORD : 1
+QDC0 = DWORD : 1
+TDC0 = DWORD : 1
+SCLR = DWORD : 1
+PAT0 = DWORD : 1
+ACUM = DWORD : 1
+CADC = DWORD : 1
+ASUM = DWORD : 1
+ETCR = DWORD : 0
+PADD = DWORD : 1
+TDC1 = DWORD : 1
+SCLD = DWORD : 1
+
+[/Analyzer]
+Book TTree = BOOL : n
+ODB Load = BOOL : n
+
+[/Analyzer/WireChamber/Common]
+Event ID = INT : 1
+Trigger mask = INT : -1
+Sampling type = INT : 2
+Buffer = STRING : [32] SYSTEM
+Enabled = BOOL : y
+Client name = STRING : [32] Analyzer
+Host = STRING : [32] k600daq
+
+[/Analyzer/WireChamber/Statistics]
+Events received = DOUBLE : 4366
+Events per sec. = DOUBLE : 49500
+Events written = DOUBLE : 0
+
+[/Analyzer/Tree switches/run]
+Read = BOOL : n
+Write = BOOL : n
+Fill = BOOL : n
+Save Config = BOOL : n
+Compression Level = INT : 0
+Max Entries = INT : 0
+
+[/Analyzer/Tasks/PrintValues]
+Active = BOOL : n
+TaskTestValue = INT : 0
+
+[/Analyzer/Tasks/GenerateRawSpectra]
+Active = BOOL : n
+
+[/Analyzer/Tasks/FillRawSpectra]
+Active = BOOL : n
+
+[/Analyzer/Global Steering Parameters]
+TestValue = INT : 0
+
+[/Analyzer/Tabs/Raw]
+Active = BOOL : n
+
+[/Analyzer/Tabs/Wires]
+Active = BOOL : n
+
+[/Analyzer/Tabs/Mon]
+Active = BOOL : n
+
+[/Analyzer/Tabs/WireHits]
+Active = BOOL : n
 

--- a/main.c
+++ b/main.c
@@ -946,7 +946,7 @@ INT main_bor(INT run_number)
 //================================================================================================
 INT main_event(EVENT_HEADER * pheader, void *pevent)
 {
-   //printf("L2218\n");
+   //printf("main.c L949\n");
    DWORD *ptdc;
    Int_t ntdc = 0;
    Int_t tdc1190datacode, tdc1190error, tdc1190trailerstatus;
@@ -1118,9 +1118,9 @@ INT main_event(EVENT_HEADER * pheader, void *pevent)
 
    getRefTimes(reftimes,ntdc,ptdc);       // reftimes[i] is copy of trigger in TDC i. Each TDC should only have 1 value/event
  
-   // loop through all the TDC datawords===================================================================================================
-   //hTDCPerEvent->Fill(ntdc);          // a diagnostic: to see how many TDC channels per event 
-   
+   // ===loop through all the TDC datawords================================================================================================
+
+   //hTDCPerEvent->Fill(ntdc);          // a diagnostic: to see how many TDC channels per event    
    //TDC_channel_export = new int[ntdc]; //<- Declare the size of the array for the TDC data to go to any external sorts
    //TDC_value_export = new float[ntdc];
    
@@ -1129,6 +1129,9 @@ INT main_event(EVENT_HEADER * pheader, void *pevent)
         tdcmodule=(ptdc[i])&0xf;             // has bits 27-31 =1. Then ch nr goes into bits 1-5.
         continue;                            // go back to beginning of for loop as this word only tells us about tdcmodule nr
       }                                      // Raw data: 1st word has TDC module nr, then info on that module, then go to next tdcmodule
+      if(tdcmodule<0 || tdcmodule>TDCModules){
+	printf("bad tdc module nr %d\n",tdcmodule);   // error condition
+      }
       tdc1190datacode = 0x1F&((ptdc[i])>>27);
 
       #ifdef _PRINTTOSCREEN
@@ -1177,18 +1180,11 @@ INT main_event(EVENT_HEADER * pheader, void *pevent)
       channel = (0x7F&((ptdc[i])>>19));      // channel is per TDC; i.e. 0-127
       time = 0x7FFFF&(ptdc[i]);
 
-      if(tdcmodule<0 || tdcmodule>7){
-	printf("bad tdc module nr %d\n",tdcmodule);   // error condition
-      }
-
-      
-      
+ 
       ref_time = reftimes[tdcmodule] - time;     // to get accurate time info that does not suffer from trigger jitter
       
       if(tdcmodule<TDCModules){
-	hTDC2DModule[tdcmodule]->Fill(ref_time,channel); 
-	
-		
+	hTDC2DModule[tdcmodule]->Fill(ref_time,channel); 		
       }
 
       channel = channel+tdcmodule*128;                     // convert channel nr to nr in range: 0-(nr_of_tdcs)*128

--- a/main.c
+++ b/main.c
@@ -103,10 +103,6 @@ extern int TDCModules;
 
 
 /*-------------------- global variables for main --------------------*/
-#ifdef _POLARIZATION              // for PR153, Sept/Oct 2010
-const int TDC_CHAN_POLU=2;
-const int TDC_CHAN_POLD=3;
-#endif
 
 float lutx1[LUT_CHANNELS];
 float lutx2[LUT_CHANNELS];
@@ -1206,11 +1202,13 @@ INT main_event(EVENT_HEADER * pheader, void *pevent)
       TDCValueExportStore.push_back(offset_time);
 
       switch(channel){
-		case 3:  t_k600=1; break;
+		case (TDC_CHAN_PULSER): t_pulser=1; break;            // see Parameters.h. The chan = 2
+
 		case 9:  pad1hipt=ref_time;t_pad1hiPT=pad1hipt; break;
 		case 10: pad1lowpt=ref_time;t_pad1lowPT=pad1lowpt; break;
 		case 11: pad2hipt=ref_time; t_pad2hiPT=pad2hipt;break;
 		case 12: pad2lowpt=ref_time; t_pad2lowPT=pad2lowpt;break;
+
 		case TOF_TDC_CHAN: if(t_tof==0) {tof=ref_time; t_tof=tof;} break;  // this ensures only the 1st signal, not last of multiple hits, gets digitized
 		case (TOF_TDC_CHAN+1*128): if(t_toftdc2==0) toftdc2=ref_time; t_toftdc2=toftdc2; break;
 		case (TOF_TDC_CHAN+2*128): if(t_toftdc3==0) toftdc3=ref_time; t_toftdc3=toftdc3; break;
@@ -1218,7 +1216,6 @@ INT main_event(EVENT_HEADER * pheader, void *pevent)
 		case (TOF_TDC_CHAN+4*128): if(t_toftdc5==0) toftdc5=ref_time; t_toftdc5=toftdc5; break;
 		case (TOF_TDC_CHAN+5*128): if(t_toftdc6==0) toftdc6=ref_time; t_toftdc6=toftdc6; break;
 		case (TOF_TDC_CHAN+6*128): if(t_toftdc7==0) toftdc7=ref_time; t_toftdc7=toftdc7; break;
-		case (TDC_CHAN_PULSER): t_pulser=1; break; 
 		#ifdef _POLARIZATION  		
 		case (TDC_CHAN_POLU): t_polu=1; break;  // for polarized beam
 		case (TDC_CHAN_POLD): t_pold=1; break;  // for polarized beam


### PR DESCRIPTION
For reasons I dont understand the double pointer fix in adc.c (similar to the double pointer fix in main.c) that is supposed to get us around the issue of an array length not fixed at compile time (and depending on the info in config.cfg) produces a seg fault.
So for now we simply dont fill hADC2DModule, as it is not crucial to the experiment. And in the meantime I will find out what is wrong. 
In this way at least we know the code in the master branch is still usable.

Other things: I attended to point 2 in issue 102