### PR TITLE
Fixed ADC2DModule issue

### DIFF
--- a/adc.c
+++ b/adc.c
@@ -24,6 +24,8 @@
 #include <TTree.h>
 //#include <TMath.h>
 
+/* home-made includes */
+#include "Parameters.h"
 
 
 /*-- variables to be used in main.c as extern variables----------*/
@@ -75,7 +77,6 @@ extern RUNINFO runinfo;
 
 /*-- Histogramming Data Structures ----------------------------------------*/
 TH2F **hADC2DModule;
-//static TH2F *hADC2DModule[5];
 
 
 /*-- init routine --------------------------------------------------*/
@@ -84,8 +85,8 @@ INT adc_init(void)
    char name[256];
    char title[256];
    int i;
-  
-
+ 
+   printf("ADCModules = %d  ",ADCModules);
    hADC2DModule = new TH2F*[ADCModules];   
    for(int counter=0;counter<ADCModules;counter++){
 	  sprintf(name,"hADC2DModule%d",counter);
@@ -93,13 +94,6 @@ INT adc_init(void)
           hADC2DModule[counter]=new TH2F(name,title,4096,0,4096,32,0,32);
   }
 
-/*
-   for(int counter=0;counter<5;counter++){
-	  sprintf(name,"hADC2DModule%d",counter);
-	  sprintf(title,"hADC2DModule %d ",counter);
-          hADC2DModule[counter]=H2_BOOK(name,title,4096,0,4096,32,0,32);
-   }
-*/
    return SUCCESS;
 }
 
@@ -164,6 +158,7 @@ INT adc_event(EVENT_HEADER * pheader, void *pevent)
 					   // is then the arrays adc[] and ADC[] will have size of zero
    int adcchan,adcnr;
    extern int adc_counter1, adc_counter2;   // defined; declared in analyzer.c
+   int adcnrtest;
 
    /* look for ADC0 bank, return if not present */
    nwords=bk_locate(pevent, "ADC0", &padc);
@@ -176,12 +171,15 @@ INT adc_event(EVENT_HEADER * pheader, void *pevent)
    for (i = 0; i < nwords; i++){
         //printf("-------raw data 0x%08x  Nr of words %d \n",padc[i],nwords); 
         if(((padc[i]>>24)&0xff) ==0xfd) {
-           if((padc[i]&0xf) ==0) adcnr=0;  //printf(" adc nr 0 \n");}
-           if((padc[i]&0xf) ==1) adcnr=1; // printf(" adc nr 1 \n");}
-           if((padc[i]&0xf) ==2) adcnr=2;  //printf(" adc nr 2 \n");} 
-           if((padc[i]&0xf) ==3) adcnr=3; // printf(" adc nr 3 \n");}
-           if((padc[i]&0xf) ==4) adcnr=4;  //printf(" adc nr 4 \n");}
-	   if((padc[i]&0xf) ==5) adcnr=5; //printf(" adc nr 5 \n");}
+           if((padc[i]&0xf) ==0) adcnr=0;  // printf(" adc nr 0 \n");}
+           if((padc[i]&0xf) ==1) adcnr=1;  // printf(" adc nr 1 \n");}
+           if((padc[i]&0xf) ==2) adcnr=2;  // printf(" adc nr 2 \n");} 
+           if((padc[i]&0xf) ==3) adcnr=3;  // printf(" adc nr 3 \n");}
+           if((padc[i]&0xf) ==4) adcnr=4;  // printf(" adc nr 4 \n");}
+	   if((padc[i]&0xf) ==5) adcnr=5;  // printf(" adc nr 5 \n");}
+	   if((padc[i]&0xf) ==6) adcnr=6;  // printf(" adc nr 6 \n");}
+	   if((padc[i]&0xf) ==7) adcnr=7;  // printf(" adc nr 7 \n");}
+	   if((padc[i]&0xf) ==8) adcnr=8;  // printf(" adc nr 7 \n");}
 	   //printf("-----raw data 0x%08x ->  data %d adcnr %i \n",padc[i],(padc[i]&0x0fff),adcnr); 
 	}
 	if(((padc[i]>>24)&0x7) ==0){     // if not then they are not data but header words.
@@ -192,22 +190,7 @@ INT adc_event(EVENT_HEADER * pheader, void *pevent)
             //printf("raw data 0x%08x -> chan %d data %d adcnr %i words %d \n",padc[i],adcchan,(padc[i]&0x0fff),adcnr,nwords);
           
             /* fill basic ADC histos */
-	    //hADC2DModule[adcnr]->Fill(adc[adcchan],adcchan);
-/*
-            if(adcchan<32) {
-		hADC2DModule[0]->Fill(adc[adcchan],adcchan);
-	    }  
-            else if(adcchan<64) {
-		hADC2DModule[1]->Fill(adc[adcchan],adcchan-32);
-	    }
-            else if(adcchan<96) {
-		hADC2DModule[2]->Fill(adc[adcchan],adcchan-64);
-	    }
-            else if(adcchan<128) {
-		hADC2DModule[3]->Fill(adc[adcchan],adcchan-96);
-	    }
-            else if(adcchan<160) hADC2DModule[4]->Fill(adc[adcchan],adcchan-128);  
-*/
+	    hADC2DModule[adcnr]->Fill(adc[adcchan],adcchan-32*adcnr);
 	}
 
    }

--- a/analyzer.c
+++ b/analyzer.c
@@ -30,6 +30,11 @@
 #include <TTree.h>
 #include <TFile.h>
 
+/* home-made includes */
+#include "Parameters.h"
+
+
+
 /*                   // what is this!?! I thought we are working with ROOT? 
 #ifdef HAVE_HBOOK
 #include <cfortran.h>
@@ -70,7 +75,6 @@ int trailer_bufoverflow_counter=0;
 
 /*-- Module declarations -------------------------------------------*/
 extern ANA_MODULE scaler_accum_module;
-//extern ANA_MODULE focalplane_module;
 extern ANA_MODULE main_module;
 extern ANA_MODULE qdc_module;
 extern ANA_MODULE adc_module;                    
@@ -83,7 +87,6 @@ ANA_MODULE *scaler_module[] = {
 ANA_MODULE *trigger_module[] = {
    &adc_module,					
    &qdc_module,
-//   &focalplane_module,
    &main_module,
    NULL
 };
@@ -190,6 +193,9 @@ INT analyzer_init()
    //runnr=runinfo.run_number;
 
 
+   ParameterInit();
+
+
    return SUCCESS;
 }
 
@@ -283,9 +289,8 @@ INT ana_end_of_run(INT run_number, char *error)
 
 
    // close the root file (that containst the trees) created in f-plane.c
-   extern TFile *f1;  // declared in f-plane.c
-   extern TTree *t1;  // declared in f-plane.c
-   extern TTree *t2;  // declared in f-plane.c
+   extern TFile *f1;  // declared in main.c
+   extern TTree *t1;  // declared in main.c
    f1->cd();
    f1->Write();
    f1->Close();

--- a/main.c
+++ b/main.c
@@ -462,9 +462,7 @@ INT main_init(void)
    char name[256];
    char title[256];
 
-   extern int RunNumber;
-   printf("RunNumber: \t %d\n",RunNumber);
-   ParameterInit();
+   //ParameterInit();     // now called inside init routine of analyzer.c
 
    extern bool VDC1_new, VDC2_new;
 


### PR DESCRIPTION
The problem was that the ParameterInit was called inside main.c's init routine, so the init routine in adc.c did not know wat ADCModules was. That problem is not fixed by putting ParameterInit inside the init routine in analyzer.c, which is called right at the beginning. 
