### PR TITLE
Corrected in scaler.c the inhibited channel nrs

### DIFF
--- a/scaler.c
+++ b/scaler.c
@@ -195,16 +195,16 @@ INT scaler_event(EVENT_HEADER * pheader, void *pevent)
    for(unsigned int j = 0; j <psclr[15] ; j++) {
      hBLM8->Fill(counter);
    }
-   for(unsigned int j = 0; j <psclr[20] ; j++) {   
+   for(unsigned int j = 0; j <psclr[32] ; j++) {   
      hTriggerI->Fill(counter);
    }
-   for(unsigned int j = 0; j <psclr[21] ; j++) {   
+   for(unsigned int j = 0; j <psclr[33] ; j++) {   
      hPulserI->Fill(counter);
    }
-   for(unsigned int j = 0; j <psclr[22] ; j++) {   
+   for(unsigned int j = 0; j <psclr[34] ; j++) {   
      hCII->Fill(counter);
    }
-   for(unsigned int j = 0; j <psclr[23] ; j++) {
+   for(unsigned int j = 0; j <psclr[35] ; j++) {
      hClockI->Fill(counter);
    }
 


### PR DESCRIPTION
The 4 inhibited scalers were pointing to the wrong channel nr in the SCLR section of the MIDAS file.
Now it is corrected.